### PR TITLE
Update CuraMaterial.py

### DIFF
--- a/CuraMaterial.py
+++ b/CuraMaterial.py
@@ -51,7 +51,7 @@ if platform.system() == 'Windows':
     # Get Cura User Directory
     CURA_USER_DIR = os.path.join(os.getenv('APPDATA'), 'cura')
     CURA_CONFIGS = [f.name for f in os.scandir(CURA_USER_DIR) if f.is_dir()]
-    CURA_CONFIGS.sort()
+    CURA_CONFIGS.sort(key=lambda x:int(x.replace(".","")))
     CURA_USER_MAT_DIR = os.path.join(CURA_USER_DIR, CURA_CONFIGS[-1], 'materials')
 
     # Get Cura Install Directory


### PR DESCRIPTION
UPDATE: This solution is incomplete, as there are still cases where it fails, such as after version 5.0 is released. Worth looking at, but not ready to roll in. 

Modified user directory sort under Windows, to ensure the highest version is always selected. Method is to create a sort key by removing the decimal point and converting to an integer. Doing so corrects the issue where version 4.10 is sorted between version 4.1 and 4.2, rather than after version 4.9. If the pull request is approved, a new executable could be compiled.