### PR TITLE
Update CuraMaterial.py

### DIFF
--- a/CuraMaterial.py
+++ b/CuraMaterial.py
@@ -51,7 +51,7 @@ if platform.system() == 'Windows':
     # Get Cura User Directory
     CURA_USER_DIR = os.path.join(os.getenv('APPDATA'), 'cura')
     CURA_CONFIGS = [f.name for f in os.scandir(CURA_USER_DIR) if f.is_dir()]
-    CURA_CONFIGS.sort()
+    CURA_CONFIGS.sort(key=lambda x:int(x.replace(".","" if len(x)>3 else "0")))
     CURA_USER_MAT_DIR = os.path.join(CURA_USER_DIR, CURA_CONFIGS[-1], 'materials')
 
     # Get Cura Install Directory


### PR DESCRIPTION
This fix will correct the error on Windows systems where CuraMaterial.py does not always choose the newest version directory when multiple past version directories exist. Without this fix, the versions are incorrectly sorted, like so:

```
4.0
4.1
4.10
4.11
4.12
4.2
4.9
```

This causes 4.9, in this example, to be selected as the highest version directory. With the fix applied, the list sorts like so:

```
4.0
4.1
4.2
4.9
4.10
4.11
4.12
```

Now it correctly selects the expected version 4.12.