### PR TITLE
Fixes for Cure 5.3+ and high DPI for GUI

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Spool-Maker-Fork.iml
+++ b/.idea/Spool-Maker-Fork.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.11 (Spool-Maker-Fork)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (Spool-Maker-Fork)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Spool-Maker-Fork.iml" filepath="$PROJECT_DIR$/.idea/Spool-Maker-Fork.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/CuraMaterial.py
+++ b/CuraMaterial.py
@@ -58,21 +58,33 @@ if platform.system() == 'Windows':
     # Get Cura Install Directory
     latestInstalled = None
     curaSysDir = None
-    
+
     try:
-        # Search for Cura >= v5.0 version
-        curaSysDirKey = OpenKey(HKEY_CURRENT_USER, 'Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Ultimaker-Cura.exe\\', 0, KEY_READ)
+        # Search for Cura >= v5.3 version
+        access_key = OpenKey(HKEY_LOCAL_MACHINE, 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths', 0, KEY_READ)
+        curaList = []
+        for i in range(0, QueryInfoKey(access_key)[0]):
+            curaList.append(EnumKey(access_key, i))
+            fList = [k for k in curaList if 'UltiMaker Cura' in k]
+            fList.sort()
+        curaSysDirKey = OpenKey(HKEY_LOCAL_MACHINE,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" + fList[-1], 0, KEY_READ)
         curaSysDir = os.path.dirname(QueryValueEx(curaSysDirKey, '')[0])
         latestInstalled = 5
     except:
         try:
-            # Search for Cura <= v4.13.1
-            latestVersion = getLatestKey(OpenKey(HKEY_LOCAL_MACHINE, 'SOFTWARE\\WOW6432Node\\Ultimaker B.V.', 0, KEY_READ))
-            curaSysDirKey = OpenKey(HKEY_LOCAL_MACHINE, 'SOFTWARE\\WOW6432Node\\Ultimaker B.V.\\' + latestVersion, 0, KEY_READ)
-            curaSysDir = QueryValueEx(curaSysDirKey, '')[0]
+            # Search for Cura >= v5.0 <= 5.2.1 version
+            curaSysDirKey = OpenKey(HKEY_CURRENT_USER, 'Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Ultimaker-Cura.exe\\', 0, KEY_READ)
+            curaSysDir = os.path.dirname(QueryValueEx(curaSysDirKey, '')[0])
+            latestInstalled = 5
         except:
-            print('Failed to determine Ultimaker Cura install location')
-            exit(1)
+            try:
+                # Search for Cura <= v4.13.1
+                latestVersion = getLatestKey(OpenKey(HKEY_LOCAL_MACHINE, 'SOFTWARE\\WOW6432Node\\Ultimaker B.V.', 0, KEY_READ))
+                curaSysDirKey = OpenKey(HKEY_LOCAL_MACHINE, 'SOFTWARE\\WOW6432Node\\Ultimaker B.V.\\' + latestVersion, 0, KEY_READ)
+                curaSysDir = QueryValueEx(curaSysDirKey, '')[0]
+            except:
+                print('Failed to determine Ultimaker Cura install location')
+                exit(1)
     
     CURA_INSTALL_DIR = curaSysDir
     if latestInstalled == 5:

--- a/SpoolMaker.py
+++ b/SpoolMaker.py
@@ -27,7 +27,7 @@ import sys
 import os
 import time
 
-from PyQt5 import QtWidgets, QtGui, uic
+from PyQt5 import QtWidgets, QtGui, uic, QtCore
 
 import CuraMaterial as c
 import NFCSpool as s
@@ -37,6 +37,9 @@ __copyright__ = 'Copyright 2021, Dale Osborne'
 __license__ = 'GPL'
 __version__ = '1.1.4'
 
+# Enable high DPI Scaling for the GUI
+QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True) #enable highdpi scaling
+QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True) #use highdpi icons
 
 
 # Resource loader for loading UI file with PyInstaller dist


### PR DESCRIPTION
Adds code to CuraMaterial.py to check for Cura versions 5.3 and up which changes the key location in the WIndows registry.

Adds code to SpoolMaker.py to enable high DPI scaling to fix GUI issues on newer computers with ultra-high resolution screens