### PR TITLE
Address non-number values in CURA_CONFIGS list

### DIFF
--- a/CuraMaterial.py
+++ b/CuraMaterial.py
@@ -62,9 +62,8 @@ if platform.system() == 'Windows':
     # Get Cura User Directory
     CURA_USER_DIR = os.path.join(os.getenv('APPDATA'), 'cura')
     CURA_CONFIGS = [f.name for f in os.scandir(CURA_USER_DIR) if f.is_dir()]
-    CURA_CONFIGS = [config for config in CURA_CONFIGS if is_number(config)]        # Remove any non-number values from list of curaconfigs
+    CURA_CONFIGS = [config for config in CURA_CONFIGS if is_number(config)]        # Remove any non-number values from list of cura configs
     CURA_CONFIGS.sort(key=lambda x:int(x.replace(".","" if len(x)>3 else "0")))
-    
     CURA_USER_MAT_DIR = os.path.join(CURA_USER_DIR, CURA_CONFIGS[-1], 'materials')
 
     # Get Cura Install Directory

--- a/CuraMaterial.py
+++ b/CuraMaterial.py
@@ -51,11 +51,20 @@ if platform.system() == 'Windows':
         fList = [k for k in curaList if 'Ultimaker Cura' in k]
         fList.sort()
         return fList[-1]
+
+    def is_number(s):
+        try:
+            float(s)  # Try converting to a float to handle both integers and decimals
+            return True
+        except ValueError:
+            return False
     
     # Get Cura User Directory
     CURA_USER_DIR = os.path.join(os.getenv('APPDATA'), 'cura')
     CURA_CONFIGS = [f.name for f in os.scandir(CURA_USER_DIR) if f.is_dir()]
+    CURA_CONFIGS = [config for config in CURA_CONFIGS if is_number(config)]        # Remove any non-number values from list of curaconfigs
     CURA_CONFIGS.sort(key=lambda x:int(x.replace(".","" if len(x)>3 else "0")))
+    
     CURA_USER_MAT_DIR = os.path.join(CURA_USER_DIR, CURA_CONFIGS[-1], 'materials')
 
     # Get Cura Install Directory


### PR DESCRIPTION
Added code to remove any non-numbers (for example '.sentry-native' or 'storage') that are populated when retrieving installed Cura versions, prior to sorting them. failure to remove non-numbers prior to sorting causes an exception to be thrown and SpoolMaker to crash.

See Issue report [here](https://github.com/DA-Osborne/Spool-Maker/issues/11) for example of invalid value that is populated into CURA_CONFIGS list in windows. I personally encountered the value '.sentry-native', which led me to address the issue.